### PR TITLE
Pass Library Strandedness parameter through workflow

### DIFF
--- a/bam_paired.cwl
+++ b/bam_paired.cwl
@@ -29,6 +29,8 @@ inputs:
     type: string?
   - id: synapse_parentid
     type: string
+  - id: strand_specificity
+    type: string?
 outputs:
   - id: combined_counts
     outputSource:
@@ -123,6 +125,8 @@ steps:
         source: synapseid
       - id: output_metrics_filename
         source: output_metrics_filename
+      - id: strand_specificity
+        source: strand_specificity
     out:
       - id: combined_metrics_csv
     run: subworkflows/wf-metrics.cwl

--- a/fastq_paired.cwl
+++ b/fastq_paired.cwl
@@ -25,6 +25,8 @@ inputs:
     type: string?
   - id: synapse_parentid
     type: string
+  - id: strand_specificity
+    type: string?
 outputs:
   - id: combined_counts
     outputSource:
@@ -122,6 +124,8 @@ steps:
         source: synapseid
       - id: output_metrics_filename
         source: output_metrics_filename
+      - id: strand_specificity
+        source: strand_specificity
     out:
       - id: combined_metrics_csv
     run: subworkflows/wf-metrics.cwl

--- a/fastq_single.cwl
+++ b/fastq_single.cwl
@@ -29,6 +29,8 @@ inputs:
     type: string?
   - id: synapse_parentid
     type: string
+  - id: strand_specificity
+    type: string?
 outputs:
   - id: combined_counts
     outputSource:
@@ -123,6 +125,8 @@ steps:
         source: synapseid
       - id: output_metrics_filename
         source: output_metrics_filename
+      - id: strand_specificity
+        source: strand_specificity
     out:
       - id: combined_metrics_csv
     run: subworkflows/wf-metrics.cwl

--- a/jobs/test-paired-bam/job.json
+++ b/jobs/test-paired-bam/job.json
@@ -1,6 +1,6 @@
 {
     "cwl_wf_url": "https://github.com/Sage-Bionetworks-Workflows/dockstore-workflow-rnaseq",
-    "cwl_args_url": "https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-workflow-rnaseq/master/jobs/test-main-paired/job.json",
+    "cwl_args_url": "https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-workflow-rnaseq/master/jobs/test-paired-fastq/job.json",
     "index_synapseid": "syn20835938",
     "nthreads": 15,
     "synapse_parentid": "syn20783166",

--- a/jobs/test-paired-fastq/job.json
+++ b/jobs/test-paired-fastq/job.json
@@ -13,5 +13,6 @@
     ],
     "synapseid_2": [
         "syn22119345"
-    ]
+    ],
+    "strand_specificity": "SECOND_READ_TRANSCRIPTION_STRAND"
 }

--- a/subworkflows/wf-metrics.cwl
+++ b/subworkflows/wf-metrics.cwl
@@ -32,6 +32,8 @@ inputs:
     type: string?
     'sbg:x': 211
     'sbg:y': 232
+  - id: strand_specificity
+    type: string?
 outputs:
   - id: combined_metrics_csv
     outputSource:
@@ -52,6 +54,8 @@ steps:
         source: picard_riboints
       - id: output_metrics_filename
         source: output_metrics_filename
+      - id: strand_specificity
+        source: strand_specificity
     out:
       - id: rnaseqmetrics_txt
     run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/picard_rnaseq_metrics.cwl


### PR DESCRIPTION
This parameter is commonly changed when running datasets from different studies. Thus, I've added this as an (optional) workflow argument that is passed through the metrics subworkflow.  If the argument is not supplied, the default value of "NONE" will be used (will document this in separate PR). 