### PR TITLE
Update links to tools shared in separate repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - tooltag
 jobs:
 
   test:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - tooltag
 jobs:
 
   test:

--- a/bam_paired.cwl
+++ b/bam_paired.cwl
@@ -143,7 +143,7 @@ steps:
           - wf_alignment/reads_per_gene
     out:
       - id: combined_counts
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v0.0.1/cwl/combine_counts_study.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v1.0.0/cwl/combine_counts_study.cwl
     label: Combine read counts across samples
     doc: combine read counts across all samples
     'sbg:x': -63.8984375
@@ -155,7 +155,7 @@ steps:
           - wf_metrics/combined_metrics_csv
     out:
       - id: combined_metrics
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/combine_metrics_study.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/combine_metrics_study.cwl
     label: Combine Picard metrics across samples
     doc: combine picard metrics across all samples
     'sbg:x': 343.8936767578125
@@ -167,7 +167,7 @@ steps:
           - wf_alignment/logs
     out:
       - id: starlog_merged
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v0.0.1/cwl/merge_starlog.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v1.0.0/cwl/merge_starlog.cwl
     label: merge_starlog
     doc: merge STAR log files into a single table
     'sbg:x': -132.7860107421875
@@ -205,7 +205,7 @@ steps:
       - id: clean_counts
       - id: clean_log
       - id: clean_metrics
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v0.0.1/cwl/clean_tables.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v1.0.0/cwl/clean_tables.cwl
     doc: clean output tables and convert Synapse ID's to specimen ID's
   - id: clean_upload
     in:

--- a/fastq_paired.cwl
+++ b/fastq_paired.cwl
@@ -142,7 +142,7 @@ steps:
           - wf_alignment/reads_per_gene
     out:
       - id: combined_counts
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v0.0.1/cwl/combine_counts_study.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v1.0.0/cwl/combine_counts_study.cwl
     label: Combine read counts across samples
     doc: combine read counts across all samples
     'sbg:x': -63.8984375
@@ -154,7 +154,7 @@ steps:
           - wf_metrics/combined_metrics_csv
     out:
       - id: combined_metrics
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/combine_metrics_study.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/combine_metrics_study.cwl
     label: Combine Picard metrics across samples
     doc: combine picard metrics across all samples
     'sbg:x': 343.8936767578125
@@ -166,7 +166,7 @@ steps:
           - wf_alignment/logs
     out:
       - id: starlog_merged
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v0.0.1/cwl/merge_starlog.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v1.0.0/cwl/merge_starlog.cwl
     label: merge_starlog
     doc: merge STAR log files into a single table
     'sbg:x': -132.7860107421875
@@ -204,7 +204,7 @@ steps:
       - id: clean_counts
       - id: clean_log
       - id: clean_metrics
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v0.0.1/cwl/clean_tables.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v1.0.0/cwl/clean_tables.cwl
     doc: clean output tables and convert Synapse ID's to specimen ID's
   - id: clean_upload
     in:

--- a/fastq_single.cwl
+++ b/fastq_single.cwl
@@ -142,7 +142,7 @@ steps:
           - wf_alignment/reads_per_gene
     out:
       - id: combined_counts
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v0.0.1/cwl/combine_counts_study.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v1.0.0/cwl/combine_counts_study.cwl
     label: Combine read counts across samples
     doc: combine read counts across all samples
     'sbg:x': -63.8984375
@@ -154,7 +154,7 @@ steps:
           - wf_metrics/combined_metrics_csv
     out:
       - id: combined_metrics
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/combine_metrics_study.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/combine_metrics_study.cwl
     label: Combine Picard metrics across samples
     doc: combine picard metrics across all samples
     'sbg:x': 343.8936767578125
@@ -166,7 +166,7 @@ steps:
           - wf_alignment/logs
     out:
       - id: starlog_merged
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v0.0.1/cwl/merge_starlog.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v1.0.0/cwl/merge_starlog.cwl
     label: merge_starlog
     doc: merge STAR log files into a single table
     'sbg:x': -132.7860107421875
@@ -204,7 +204,7 @@ steps:
       - id: clean_counts
       - id: clean_log
       - id: clean_metrics
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v0.0.1/cwl/clean_tables.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-rnaseq-utils/v1.0.0/cwl/clean_tables.cwl
     doc: clean output tables and convert Synapse ID's to specimen ID's
   - id: clean_upload
     in:

--- a/subworkflows/wf-alignment-paired-bam.cwl
+++ b/subworkflows/wf-alignment-paired-bam.cwl
@@ -73,7 +73,7 @@ steps:
         valueFrom: $(inputs.aligned_reads_sam.nameroot).sorted.bam
     out:
       - id: sorted_reads_bam
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/picard_sortsam.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/picard_sortsam.cwl
     label: Picard SortSam
     'sbg:x': 458.3077392578125
     'sbg:y': 207
@@ -88,7 +88,7 @@ steps:
     out:
       - id: mate_1
       - id: mate_2
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/picard_samtofastq.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/picard_samtofastq.cwl
     label: Picard SamToFastq
     'sbg:x': 769.881103515625
     'sbg:y': 93
@@ -112,7 +112,7 @@ steps:
       - id: reads_per_gene
       - id: splice_junctions
       - id: logs
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v0.0.1/cwl/star_align.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v1.0.0/cwl/star_align.cwl
     label: STAR spliced alignment
     'sbg:x': 1044.3306884765625
     'sbg:y': 193

--- a/subworkflows/wf-alignment-paired-fastq.cwl
+++ b/subworkflows/wf-alignment-paired-fastq.cwl
@@ -67,7 +67,7 @@ steps:
       - id: reads_per_gene
       - id: splice_junctions
       - id: logs
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v0.0.1/cwl/star_align.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v1.0.0/cwl/star_align.cwl
     label: STAR spliced alignment
     'sbg:x': 1044.3306884765625
     'sbg:y': 193

--- a/subworkflows/wf-alignment-single-fastq.cwl
+++ b/subworkflows/wf-alignment-single-fastq.cwl
@@ -71,7 +71,7 @@ steps:
       - id: reads_per_gene
       - id: splice_junctions
       - id: logs
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v0.0.1/cwl/star_align-se.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-star/v1.0.0/cwl/star_align-se.cwl
     label: STAR spliced alignment
     'sbg:x': 1044.3306884765625
     'sbg:y': 193

--- a/subworkflows/wf-buildrefs.cwl
+++ b/subworkflows/wf-buildrefs.cwl
@@ -36,7 +36,7 @@ steps:
         source: genemodel_gtf
     out:
       - id: picard_refflat
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/prep_refflat.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/prep_refflat.cwl
     label: Build Picard refFlat
     'sbg:x': -322
     'sbg:y': -236
@@ -48,7 +48,7 @@ steps:
         source: aligned_reads_sam
     out:
       - id: picard_riboints
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/prep_riboints.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/prep_riboints.cwl
     label: Build Picard ribosomal intervals
     'sbg:x': -319
     'sbg:y': -59

--- a/subworkflows/wf-metrics.cwl
+++ b/subworkflows/wf-metrics.cwl
@@ -58,7 +58,7 @@ steps:
         source: strand_specificity
     out:
       - id: rnaseqmetrics_txt
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/picard_rnaseq_metrics.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/picard_rnaseq_metrics.cwl
     label: Picard CollectRnaSeqMetrics
     'sbg:x': -71
     'sbg:y': -21
@@ -72,7 +72,7 @@ steps:
         source: output_metrics_filename
     out:
       - id: alignmentsummarymetrics_txt
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/picard_alignmentsummary_metrics.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/picard_alignmentsummary_metrics.cwl
     label: Picard CollectAlignmentSummaryMetrics module
     'sbg:x': -72
     'sbg:y': -251
@@ -88,7 +88,7 @@ steps:
         valueFrom: $(inputs.basef).csv
     out:
       - id: combined_metrics_csv
-    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v0.0.1/cwl/combine_metrics_sample.cwl
+    run: https://raw.githubusercontent.com/Sage-Bionetworks-Workflows/dockstore-tool-picardtools/v1.0.0/cwl/combine_metrics_sample.cwl
     label: Combine Picard metrics per sample
     'sbg:x': 192.60113525390625
     'sbg:y': -121


### PR DESCRIPTION
Major releases have been made for the picardtools, star, and rnaseq-utils tool repos. This PR updates the links to these tools in all workflows and subworkflows 